### PR TITLE
Using opaque identifier instead of strings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
       "name": "Debug rulox",
       "type": "lldb",
       "request": "launch",
-      "program": "target/debug/rulox-9dbf730e028ff499",
+      "program": "target/debug/rulox",
       "args": "--test lexical_scope_resolver::tests::captured_variable",
       "cwd": "${workspaceRoot}"
     }

--- a/src/ast
+++ b/src/ast
@@ -49,7 +49,7 @@ impl IdentifierMap {
 
     pub fn from_name(&mut self, name: &str) -> Identifier {
         if let Some(identifier) = self.map.get(name) {
-            return *identifier;
+            return *identifier
         }
         let identifier = Identifier { handle: self.next };
         self.next = self.next + 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,15 +65,15 @@ fn run(parser: &mut Parser,
             // Once we get the statements and their AST we run the following passes:
             // - lexical analysis
             // - actual interpretation
-            let mut resolution_errors = vec!();
+            let mut resolution_errors = vec![];
             for statement in statements.iter() {
                 match lexical_scope_resolver.resolve(&statement) {
                     Ok(_) => (),
                     Err(e) => resolution_errors.push(e),
                 }
             }
-            if !resolution_errors.is_empty(){
-                return  RunResult::LexicalScopesResolutionError(resolution_errors);
+            if !resolution_errors.is_empty() {
+                return RunResult::LexicalScopesResolutionError(resolution_errors);
             }
             for statement in statements.iter() {
                 match interpreter.execute(lexical_scope_resolver, &statement) {
@@ -95,7 +95,7 @@ fn run_file(file_name: &str) -> RunResult {
         Ok(mut file) => {
             let mut parser = Parser::new();
             let mut lexical_scope_resolver = ProgramLexicalScopesResolver::new();
-            let mut interpreter = StatementInterpreter::new();
+            let mut interpreter = StatementInterpreter::new(&mut parser.identifier_map);
             let mut source = String::new();
             match file.read_to_string(&mut source) {
                 Err(_) => {
@@ -116,7 +116,7 @@ fn run_prompt() -> RunResult {
     println!("Rulox - A lox interpreter written in Rust");
     let mut parser = Parser::new();
     let mut lexical_scope_resolver = ProgramLexicalScopesResolver::new();
-    let mut interpreter = StatementInterpreter::new();
+    let mut interpreter = StatementInterpreter::new(&mut parser.identifier_map);
     let _ = io::stdout().flush(); //TODO: is this okay?
     loop {
         print!("> ");

--- a/src/pretty_printer.rs
+++ b/src/pretty_printer.rs
@@ -1,32 +1,35 @@
 use ast::*;
 
 pub trait PrettyPrint {
-    fn pretty_print_into(&self, pretty_printed: &mut String) -> ();
-    fn pretty_print(&self) -> String {
+    fn pretty_print_into(&self, identifier_map: &IdentifierMap, pretty_printed: &mut String) -> ();
+    fn pretty_print(&self, identifier_map: &IdentifierMap) -> String {
         let mut pretty_printed = String::new();
-        self.pretty_print_into(&mut pretty_printed);
+        self.pretty_print_into(identifier_map, &mut pretty_printed);
         pretty_printed
     }
 }
 
 impl PrettyPrint for Expr {
-    fn pretty_print_into(&self, pretty_printed: &mut String) -> () {
+    fn pretty_print_into(&self, identifier_map: &IdentifierMap, pretty_printed: &mut String) -> () {
         match *self {
-            Expr::Literal(ref l) => l.pretty_print_into(pretty_printed),
-            Expr::Unary(ref u) => u.pretty_print_into(pretty_printed),
-            Expr::Binary(ref b) => b.pretty_print_into(pretty_printed),
-            Expr::Logic(ref b) => b.pretty_print_into(pretty_printed),
-            Expr::Grouping(ref g) => g.pretty_print_into(pretty_printed),
-            Expr::Identifier(ref _h, ref i) => i.pretty_print_into(pretty_printed),
-            Expr::Assignment(ref a) => a.pretty_print_into(pretty_printed),
-            Expr::Call(ref c) => c.pretty_print_into(pretty_printed),
+            Expr::Literal(ref l) => l.pretty_print_into(identifier_map, pretty_printed),
+            Expr::Unary(ref u) => u.pretty_print_into(identifier_map, pretty_printed),
+            Expr::Binary(ref b) => b.pretty_print_into(identifier_map, pretty_printed),
+            Expr::Logic(ref b) => b.pretty_print_into(identifier_map, pretty_printed),
+            Expr::Grouping(ref g) => g.pretty_print_into(identifier_map, pretty_printed),
+            Expr::Identifier(ref _h, ref i) => i.pretty_print_into(identifier_map, pretty_printed),
+            Expr::Assignment(ref a) => a.pretty_print_into(identifier_map, pretty_printed),
+            Expr::Call(ref c) => c.pretty_print_into(identifier_map, pretty_printed),
 
         }
     }
 }
 
 impl PrettyPrint for UnaryOperator {
-    fn pretty_print_into(&self, pretty_printed: &mut String) -> () {
+    fn pretty_print_into(&self,
+                         _identifier_map: &IdentifierMap,
+                         pretty_printed: &mut String)
+                         -> () {
         match *self {
             UnaryOperator::Bang => pretty_printed.push_str("!"),
             UnaryOperator::Minus => pretty_printed.push_str("-"),
@@ -35,7 +38,10 @@ impl PrettyPrint for UnaryOperator {
 }
 
 impl PrettyPrint for BinaryOperator {
-    fn pretty_print_into(&self, pretty_printed: &mut String) -> () {
+    fn pretty_print_into(&self,
+                         _identifier_map: &IdentifierMap,
+                         pretty_printed: &mut String)
+                         -> () {
         match *self {
             BinaryOperator::Minus => pretty_printed.push_str("-"),
             BinaryOperator::Plus => pretty_printed.push_str("+"),
@@ -52,7 +58,10 @@ impl PrettyPrint for BinaryOperator {
 }
 
 impl PrettyPrint for LogicOperator {
-    fn pretty_print_into(&self, pretty_printed: &mut String) -> () {
+    fn pretty_print_into(&self,
+                         _identifier_map: &IdentifierMap,
+                         pretty_printed: &mut String)
+                         -> () {
         match *self {
             LogicOperator::Or => pretty_printed.push_str("or"),
             LogicOperator::And => pretty_printed.push_str("and"),
@@ -61,7 +70,10 @@ impl PrettyPrint for LogicOperator {
 }
 
 impl PrettyPrint for Literal {
-    fn pretty_print_into(&self, pretty_printed: &mut String) -> () {
+    fn pretty_print_into(&self,
+                         _identifier_map: &IdentifierMap,
+                         pretty_printed: &mut String)
+                         -> () {
         match *self {
             Literal::NilLiteral => pretty_printed.push_str("null"),
             Literal::BoolLiteral(ref b) => pretty_printed.push_str(&b.to_string()),
@@ -72,150 +84,162 @@ impl PrettyPrint for Literal {
 }
 
 impl PrettyPrint for Identifier {
-    fn pretty_print_into(&self, pretty_printed: &mut String) -> () {
-        pretty_printed.push_str(&self.name)
+    fn pretty_print_into(&self, identifier_map: &IdentifierMap, pretty_printed: &mut String) -> () {
+        pretty_printed.push_str(identifier_map.lookup(self).unwrap())
     }
 }
 
 impl PrettyPrint for Target {
-    fn pretty_print_into(&self, pretty_printed: &mut String) -> () {
+    fn pretty_print_into(&self, identifier_map: &IdentifierMap, pretty_printed: &mut String) -> () {
         match *self {
-            Target::Identifier(ref i) => i.pretty_print_into(pretty_printed),
+            Target::Identifier(ref i) => i.pretty_print_into(identifier_map, pretty_printed),
         }
     }
 }
 
 impl PrettyPrint for Assignment {
-    fn pretty_print_into(&self, pretty_printed: &mut String) -> () {
-        self.lvalue.pretty_print_into(pretty_printed);
+    fn pretty_print_into(&self, identifier_map: &IdentifierMap, pretty_printed: &mut String) -> () {
+        self.lvalue
+            .pretty_print_into(identifier_map, pretty_printed);
         pretty_printed.push_str(" = ");
-        self.rvalue.pretty_print_into(pretty_printed);
+        self.rvalue
+            .pretty_print_into(identifier_map, pretty_printed);
     }
 }
 
 impl PrettyPrint for Grouping {
-    fn pretty_print_into(&self, pretty_printed: &mut String) -> () {
+    fn pretty_print_into(&self, identifier_map: &IdentifierMap, pretty_printed: &mut String) -> () {
         pretty_printed.push_str("(group ");
-        self.expr.pretty_print_into(pretty_printed);
+        self.expr.pretty_print_into(identifier_map, pretty_printed);
         pretty_printed.push_str(")");
     }
 }
 
 impl PrettyPrint for UnaryExpr {
-    fn pretty_print_into(&self, pretty_printed: &mut String) -> () {
+    fn pretty_print_into(&self, identifier_map: &IdentifierMap, pretty_printed: &mut String) -> () {
         pretty_printed.push_str("(");
-        self.operator.pretty_print_into(pretty_printed);
+        self.operator
+            .pretty_print_into(identifier_map, pretty_printed);
         pretty_printed.push_str(" ");
-        self.right.pretty_print_into(pretty_printed);
+        self.right.pretty_print_into(identifier_map, pretty_printed);
         pretty_printed.push_str(")");
     }
 }
 
 impl PrettyPrint for LogicExpr {
-    fn pretty_print_into(&self, pretty_printed: &mut String) -> () {
+    fn pretty_print_into(&self, identifier_map: &IdentifierMap, pretty_printed: &mut String) -> () {
         pretty_printed.push_str("(");
-        self.operator.pretty_print_into(pretty_printed);
+        self.operator
+            .pretty_print_into(identifier_map, pretty_printed);
         pretty_printed.push_str(" ");
-        self.left.pretty_print_into(pretty_printed);
+        self.left.pretty_print_into(identifier_map, pretty_printed);
         pretty_printed.push_str(" ");
-        self.right.pretty_print_into(pretty_printed);
+        self.right.pretty_print_into(identifier_map, pretty_printed);
         pretty_printed.push_str(")");
     }
 }
 
 impl PrettyPrint for BinaryExpr {
-    fn pretty_print_into(&self, pretty_printed: &mut String) -> () {
+    fn pretty_print_into(&self, identifier_map: &IdentifierMap, pretty_printed: &mut String) -> () {
         pretty_printed.push_str("(");
-        self.operator.pretty_print_into(pretty_printed);
+        self.operator
+            .pretty_print_into(identifier_map, pretty_printed);
         pretty_printed.push_str(" ");
-        self.left.pretty_print_into(pretty_printed);
+        self.left.pretty_print_into(identifier_map, pretty_printed);
         pretty_printed.push_str(" ");
-        self.right.pretty_print_into(pretty_printed);
+        self.right.pretty_print_into(identifier_map, pretty_printed);
         pretty_printed.push_str(")");
     }
 }
 
 impl PrettyPrint for Statement {
-    fn pretty_print_into(&self, pretty_printed: &mut String) -> () {
+    fn pretty_print_into(&self, identifier_map: &IdentifierMap, pretty_printed: &mut String) -> () {
         match *self {
             Statement::Print(ref e) => {
                 pretty_printed.push_str("print ");
-                e.pretty_print_into(pretty_printed);
+                e.pretty_print_into(identifier_map, pretty_printed);
                 pretty_printed.push_str(";");
             }
             Statement::Return(ref e) => {
                 pretty_printed.push_str("return");
                 if let &Some(ref e) = e {
                     pretty_printed.push_str(" ");
-                    e.pretty_print_into(pretty_printed);
+                    e.pretty_print_into(identifier_map, pretty_printed);
                 }
                 pretty_printed.push_str(";");
             }
             Statement::Expression(ref e) => {
-                e.pretty_print_into(pretty_printed);
+                e.pretty_print_into(identifier_map, pretty_printed);
                 pretty_printed.push_str(";");
             }
             Statement::VariableDefinition(ref identifier) => {
                 pretty_printed.push_str("var ");
-                identifier.pretty_print_into(pretty_printed);
+                identifier.pretty_print_into(identifier_map, pretty_printed);
                 pretty_printed.push_str(";");
             }
             Statement::VariableDefinitionWithInitalizer(ref identifier, ref initializer) => {
                 pretty_printed.push_str("var ");
-                identifier.pretty_print_into(pretty_printed);
+                identifier.pretty_print_into(identifier_map, pretty_printed);
                 pretty_printed.push_str(" = ");
-                initializer.pretty_print_into(pretty_printed);
+                initializer.pretty_print_into(identifier_map, pretty_printed);
                 pretty_printed.push_str(";");
             }
             Statement::Block(ref b) => {
                 pretty_printed.push_str("{ ");
                 for statement in &b.statements {
-                    statement.pretty_print_into(pretty_printed);
+                    statement.pretty_print_into(identifier_map, pretty_printed);
                     pretty_printed.push_str(" ");
                 }
                 pretty_printed.push_str("}");
             }
             Statement::IfThen(ref c) => {
                 pretty_printed.push_str("if ( ");
-                c.condition.pretty_print_into(pretty_printed);
+                c.condition
+                    .pretty_print_into(identifier_map, pretty_printed);
                 pretty_printed.push_str(" ) ");
-                c.then_branch.pretty_print_into(pretty_printed);
+                c.then_branch
+                    .pretty_print_into(identifier_map, pretty_printed);
             }
             Statement::IfThenElse(ref c) => {
                 pretty_printed.push_str("if ( ");
-                c.condition.pretty_print_into(pretty_printed);
+                c.condition
+                    .pretty_print_into(identifier_map, pretty_printed);
                 pretty_printed.push_str(" ) ");
-                c.then_branch.pretty_print_into(pretty_printed);
+                c.then_branch
+                    .pretty_print_into(identifier_map, pretty_printed);
                 pretty_printed.push_str(" else ");
-                c.else_branch.pretty_print_into(pretty_printed);
+                c.else_branch
+                    .pretty_print_into(identifier_map, pretty_printed);
             }
             Statement::While(ref l) => {
                 pretty_printed.push_str("while ( ");
-                l.condition.pretty_print_into(pretty_printed);
+                l.condition
+                    .pretty_print_into(identifier_map, pretty_printed);
                 pretty_printed.push_str(" ) ");
-                l.body.pretty_print_into(pretty_printed);
+                l.body.pretty_print_into(identifier_map, pretty_printed);
             }
             Statement::FunctionDefinition(ref f) => {
                 pretty_printed.push_str("fun ");
-                f.name.pretty_print_into(pretty_printed);
+                f.name.pretty_print_into(identifier_map, pretty_printed);
                 pretty_printed.push_str(" (");
                 for argument in &f.arguments {
-                    argument.pretty_print_into(pretty_printed);
+                    argument.pretty_print_into(identifier_map, pretty_printed);
                     pretty_printed.push_str(" ");
                 }
                 pretty_printed.push_str(") ");
-                f.body.pretty_print_into(pretty_printed);
+                f.body.pretty_print_into(identifier_map, pretty_printed);
             }
         };
     }
 }
 
 impl PrettyPrint for Call {
-    fn pretty_print_into(&self, pretty_printed: &mut String) -> () {
-        self.callee.pretty_print_into(pretty_printed);
+    fn pretty_print_into(&self, identifier_map: &IdentifierMap, pretty_printed: &mut String) -> () {
+        self.callee
+            .pretty_print_into(identifier_map, pretty_printed);
         pretty_printed.push_str("( ");
         for arg in self.arguments.iter() {
-            arg.pretty_print_into(pretty_printed);
+            arg.pretty_print_into(identifier_map, pretty_printed);
             pretty_printed.push_str(" ");
         }
         pretty_printed.push_str(")");
@@ -229,13 +253,15 @@ mod tests {
 
     #[test]
     fn literal() {
+        let identifier_map = IdentifierMap::new();
         let string = String::from("abc");
         let expr = Expr::Literal(Literal::StringLiteral(string.clone()));
-        assert_eq!(string, expr.pretty_print());
+        assert_eq!(string, expr.pretty_print(&identifier_map));
     }
 
     #[test]
     fn complex_expression() {
+        let identifier_map = IdentifierMap::new();
         let subexpr1 = UnaryExpr {
             operator: UnaryOperator::Minus,
             right: Expr::Literal(Literal::NumberLiteral(123f64)),
@@ -247,13 +273,14 @@ mod tests {
             right: Expr::Grouping(Box::new(subexpr2)),
         };
         let expr = Expr::Binary(Box::new(binary_expr));
-        assert_eq!("(* (- 123) (group 45.67))", &expr.pretty_print());
+        assert_eq!("(* (- 123) (group 45.67))", &expr.pretty_print(&identifier_map));
     }
 
     #[test]
     fn block() {
+        let mut identifier_map = IdentifierMap::new();
         let mut handle_factory = VariableUseHandleFactory::new();
-        let identifier = Identifier { name: "x".into() };
+        let identifier = identifier_map.from_name(&"x");
         let statements = vec![
             Statement::VariableDefinitionWithInitalizer(
                 identifier.clone(),
@@ -263,6 +290,6 @@ mod tests {
                 Expr::Identifier(handle_factory.next(), identifier.clone()))
                     ];
         let block = Statement::Block(Box::new(Block { statements: statements }));
-        assert_eq!("{ var x = true; print x; }", &block.pretty_print());
+        assert_eq!("{ var x = true; print x; }", &block.pretty_print(&identifier_map));
     }
 }


### PR DESCRIPTION
This saves us to keep copying strings around all the time.
The price to pay for this is that we need to keep a mapping, but that's used only when parsing (with no additional cost) and pretty printing (so only for testing)

This solves issue #1 