### PR TITLE
fix 48 warnings in rust version 1.47

### DIFF
--- a/src/frontend/scanner.rs
+++ b/src/frontend/scanner.rs
@@ -127,7 +127,7 @@ impl<'a> Scanner<'a> {
         }
     }
 
-    fn peek_check(&mut self, check: &Fn(char) -> bool) -> bool {
+    fn peek_check(&mut self, check: &dyn Fn(char) -> bool) -> bool {
         self.source.reset_peek();
         match self.source.peek() {
             Some(&c) => check(c),
@@ -135,7 +135,11 @@ impl<'a> Scanner<'a> {
         }
     }
 
-    fn peek_check2(&mut self, check1: &Fn(char) -> bool, check2: &Fn(char) -> bool) -> bool {
+    fn peek_check2(
+        &mut self,
+        check1: &dyn Fn(char) -> bool,
+        check2: &dyn Fn(char) -> bool,
+    ) -> bool {
         self.source.reset_peek();
         match self.source.peek() {
             Some(&p1) => match self.source.peek() {
@@ -153,7 +157,7 @@ impl<'a> Scanner<'a> {
             if c == '\n' {
                 self.current_position.increment_line();
             } else {
-                self.current_position.increment_column();;
+                self.current_position.increment_column();
             }
         };
         next
@@ -168,7 +172,7 @@ impl<'a> Scanner<'a> {
         }
     }
 
-    fn advance_while(&mut self, condition: &Fn(char) -> bool) -> () {
+    fn advance_while(&mut self, condition: &dyn Fn(char) -> bool) -> () {
         while self.peek_check(condition) {
             self.advance();
         }
@@ -420,5 +424,4 @@ mod tests {
         assert_eq!(tokens[7].token, Token::Semicolon);
         assert_eq!(errors.len(), 1);
     }
-
 }

--- a/src/treewalk/parser.rs
+++ b/src/treewalk/parser.rs
@@ -167,8 +167,10 @@ impl Parser {
     fn parse_semicolon_terminated_statement<'a, I>(
         &mut self,
         tokens: &mut Peekable<I>,
-        parse_statement: &Fn(&mut Parser, &mut Peekable<I>)
-            -> Option<Result<Statement, ParseError>>,
+        parse_statement: &dyn Fn(
+            &mut Parser,
+            &mut Peekable<I>,
+        ) -> Option<Result<Statement, ParseError>>,
     ) -> Option<Result<Statement, ParseError>>
     where
         I: Iterator<Item = &'a TokenWithContext>,
@@ -643,8 +645,11 @@ impl Parser {
     fn parse_logic<'a, I>(
         &mut self,
         tokens: &mut Peekable<I>,
-        map_operator: &Fn(&Token) -> Option<LogicOperator>,
-        parse_subexpression: &Fn(&mut Parser, &mut Peekable<I>) -> Option<Result<Expr, ParseError>>,
+        map_operator: &dyn Fn(&Token) -> Option<LogicOperator>,
+        parse_subexpression: &dyn Fn(
+            &mut Parser,
+            &mut Peekable<I>,
+        ) -> Option<Result<Expr, ParseError>>,
     ) -> Option<Result<Expr, ParseError>>
     where
         I: Iterator<Item = &'a TokenWithContext>,
@@ -685,8 +690,11 @@ impl Parser {
     fn parse_binary<'a, I>(
         &mut self,
         tokens: &mut Peekable<I>,
-        map_operator: &Fn(&Token) -> Option<BinaryOperator>,
-        parse_subexpression: &Fn(&mut Parser, &mut Peekable<I>) -> Option<Result<Expr, ParseError>>,
+        map_operator: &dyn Fn(&Token) -> Option<BinaryOperator>,
+        parse_subexpression: &dyn Fn(
+            &mut Parser,
+            &mut Peekable<I>,
+        ) -> Option<Result<Expr, ParseError>>,
     ) -> Option<Result<Expr, ParseError>>
     where
         I: Iterator<Item = &'a TokenWithContext>,
@@ -942,16 +950,12 @@ impl Parser {
     fn parse_function_arguments<'a, I, A>(
         &mut self,
         tokens: &mut Peekable<I>,
-        parse_argument: &Fn(&mut Parser, &mut Peekable<I>) -> Option<Result<A, ParseError>>,
+        parse_argument: &dyn Fn(&mut Parser, &mut Peekable<I>) -> Option<Result<A, ParseError>>,
     ) -> Result<Vec<A>, ParseError>
     where
         I: Iterator<Item = &'a TokenWithContext>,
     {
-        try!(consume_expected_token!(
-            tokens,
-            &Token::LeftParen,
-            RequiredElement::LeftParen
-        ));
+        consume_expected_token!(tokens, &Token::LeftParen, RequiredElement::LeftParen)?;
         let mut arguments = vec![];
         if let Some(&Token::RightParen) = tokens.peek().map(|t| &t.token) {
         } else {
@@ -973,11 +977,7 @@ impl Parser {
                 }
             }
         }
-        try!(consume_expected_token!(
-            tokens,
-            &Token::RightParen,
-            RequiredElement::RightParen
-        ));
+        consume_expected_token!(tokens, &Token::RightParen, RequiredElement::RightParen)?;
         Ok(arguments)
     }
 

--- a/src/vm/bytecode.rs
+++ b/src/vm/bytecode.rs
@@ -139,21 +139,21 @@ pub fn disassemble<T>(chunk: &Chunk, name: &str, out: &mut LineWriter<T>) -> Res
 where
     T: Write,
 {
-    try!(writeln!(out, "== {} ==", name));
+    writeln!(out, "== {} ==", name)?;
     let mut line = 0;
     for (i, instruction) in chunk.instructions.iter().enumerate() {
         // Note that this is not printing offsets as the book does.
         // Using the OpCode enum all the opcodes have the same size.
         // It is not space-efficient, but for now it's fine
-        try!(write!(out, "{:04}", i));
+        write!(out, "{:04}", i)?;
         if line == chunk.lines[i] {
-            try!(write!(out, "   |"));
+            write!(out, "   |")?;
         } else {
             line = chunk.lines[i];
-            try!(write!(out, "{:4}", line));
+            write!(out, "{:4}", line)?;
         }
-        try!(write!(out, " "));
-        try!{disassemble_instruction(instruction, chunk, out)};
+        write!(out, " ")?;
+        disassemble_instruction(instruction, chunk, out)?;
     }
     Ok(())
 }


### PR DESCRIPTION
All 48 of the warnings surrounding the following 2 issues have been resolved:

use of deprecated macro `try`: use the `?` operator instead

trait objects without an explicit `dyn` are deprecated